### PR TITLE
.bumpversion.cfg has a bad file reference for the cookiecutter

### DIFF
--- a/ansible-play-{{cookiecutter.playbook_name}}/.bumpversion.cfg
+++ b/ansible-play-{{cookiecutter.playbook_name}}/.bumpversion.cfg
@@ -5,5 +5,5 @@ tag = True
 
 [bumpversion:file:VERSION]
 
-[bumpversion:file:local.yml]
+[bumpversion:file:playbook.yml]
 parse = {{cookiecutter.playbook_name}} v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)


### PR DESCRIPTION
This bumpversion config is referencing a file that doesn't exist in the cookiecutter template. I think should be referencing playbook.yml.